### PR TITLE
Fix unzip-alist to actually work as the function name suggests 

### DIFF
--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -18,7 +18,7 @@
    (unzip-alist '((a . 1) (b . 2) (c . 3))) => (a b c); (1 2 3)"
   (values
     (mapcar #'car alist)
-    (mapcar #'cdr alist))
+    (mapcar #'cdr alist)))
 
 (defmacro fun (&body body)
   "This macro puts the FUN back in FUNCTION."


### PR DESCRIPTION
The original iterative version made little sense, especially using the on
keyword instead of in. It did not work as intended.

To make this work on a more friendly sibling of the alist (namely,
nested lists: ((a 1) (b 2) (c 3))), use #'first and #'second instead
of #'car and #'cdr, respectively.
