### PR TITLE
Disable actors with ECL

### DIFF
--- a/chanl.asd
+++ b/chanl.asd
@@ -22,7 +22,7 @@
                          (:file "queues")
                          (:file "channels")
                          (:file "select")
-                         (:file "actors"))))
+                         #-ecl (:file "actors"))))
   :in-order-to ((test-op (test-op "chanl/tests"))))
 
 (defsystem "chanl/examples"
@@ -55,7 +55,7 @@
                          (:file "queues")
                          (:file "channels")
                          (:file "select")
-                         (:file "actors"))))
+                         #-ecl (:file "actors"))))
   :perform
   (test-op (o c)
     (format t "~2&*******************~@


### PR DESCRIPTION
The CHANL.ACTORS package uses the :ARGUMENTS option of
DEFINE-METHOD-COMBINATION, which is not implemented in ECL yet
(see https://gitlab.com/embeddable-common-lisp/ecl/issues/305). So let's
disable it for now, as it allows compiling the library and using the rest
of it.