### PR TITLE
Fix loss of :compare-and-swap-vops from *features* in SBCL

### DIFF
--- a/src/trivial-cas.lisp
+++ b/src/trivial-cas.lisp
@@ -8,6 +8,14 @@
 ;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+#+ sbcl
+(eval-when (:load-toplevel :compile-toplevel :execute)
+  (let ((package (find-package :sb-impl)))
+    (when package
+      (let ((sym (find-symbol (string :+internal-features+) package)))
+        (when (and (boundp sym) (member :compare-and-swap-vops (symbol-value sym)))
+          (pushnew :compare-and-swap-vops *features*))))))
+
 (defpackage :trivial-compare-and-swap
   (:use :cl)
   (:nicknames :trivial-cas)


### PR DESCRIPTION
SBCL recently removed a bunch of "internal" features from *features*.  Unfortunately, chanl was depending on one.   The symbol is now in sb-impl:+internal-features+; if it's there under  SBCL then put it back on *features*.